### PR TITLE
Update class-wc-maxipago-api.php: troca de chaves por colchetes

### DIFF
--- a/includes/class-wc-maxipago-api.php
+++ b/includes/class-wc-maxipago-api.php
@@ -283,10 +283,10 @@ abstract class WC_maxiPago_API
             } else {
                 for ($t = 9; $t < 11; $t++) {
                     for ($d = 0, $c = 0; $c < $t; $c++) {
-                        $d += $document{$c} * (($t + 1) - $c);
+                        $d += $document[$c] * (($t + 1) - $c);
                     }
                     $d = ((10 * $d) % 11) % 10;
-                    if ($document{$c} != $d) {
+                    if ($document[$c] != $d) {
                         return false;
                     }
                 }


### PR DESCRIPTION
Depois da versão 7.4 do PHP não é mais possível usar chaves para arrays, apenas colchetes.